### PR TITLE
Fix multithread tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ Runs all of the nine tests, collects their output scores, and processes them to 
 
 <table><tbody>
 <tr><th>Type:</th><td><code>scope</code></td><tr><th>Root object:</th><td>SuccessOutput</td></tr>
-<tr><th>Properties</th><td><details><summary>coremark_pro_params (<code>reference[CertifyAllParams]</code>)</summary>
+<tr><th>Properties</th><td><details><summary>coremark_pro_command (<code>string</code>)</summary>
+                <table><tbody><tr><th>Name:</th><td>CoreMark®-PRO command line</td></tr><tr><th>Description:</th><td width="500">The complete command line passed to CoreMark®-PRO</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
+            </details><details><summary>coremark_pro_params (<code>reference[CertifyAllParams]</code>)</summary>
                 <table><tbody><tr><th>Name:</th><td>Test Params</td></tr><tr><th>Description:</th><td width="500">The parameters supplied to the CoreMark®-PRO benchmarks</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>reference[CertifyAllParams]</code></td><tr><th>Referenced object:</th><td>CertifyAllParams</td></tr></tbody></table>
             </details><details><summary>coremark_pro_results (<code>reference[CertifyAllResult]</code>)</summary>
                 <table><tbody><tr><th>Name:</th><td>Test Results</td></tr><tr><th>Description:</th><td width="500">Results of the CoreMark®-PRO benchmarks</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>reference[CertifyAllResult]</code></td><tr><th>Referenced object:</th><td>CertifyAllResult</td></tr></tbody></table>
@@ -204,7 +206,9 @@ Runs all of the nine tests, collects their output scores, and processes them to 
         </details></td></tr>
 </tbody></table>
         </details><details><summary>SuccessOutput (<code>object</code>)</summary>
-            <table><tbody><tr><th>Type:</th><td><code>object</code></td><tr><th>Properties</th><td><details><summary>coremark_pro_params (<code>reference[CertifyAllParams]</code>)</summary>
+            <table><tbody><tr><th>Type:</th><td><code>object</code></td><tr><th>Properties</th><td><details><summary>coremark_pro_command (<code>string</code>)</summary>
+        <table><tbody><tr><th>Name:</th><td>CoreMark®-PRO command line</td></tr><tr><th>Description:</th><td width="500">The complete command line passed to CoreMark®-PRO</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
+        </details><details><summary>coremark_pro_params (<code>reference[CertifyAllParams]</code>)</summary>
         <table><tbody><tr><th>Name:</th><td>Test Params</td></tr><tr><th>Description:</th><td width="500">The parameters supplied to the CoreMark®-PRO benchmarks</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>reference[CertifyAllParams]</code></td><tr><th>Referenced object:</th><td>CertifyAllParams</td></tr></tbody></table>
         </details><details><summary>coremark_pro_results (<code>reference[CertifyAllResult]</code>)</summary>
         <table><tbody><tr><th>Name:</th><td>Test Results</td></tr><tr><th>Description:</th><td width="500">Results of the CoreMark®-PRO benchmarks</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>reference[CertifyAllResult]</code></td><tr><th>Referenced object:</th><td>CertifyAllResult</td></tr></tbody></table>

--- a/arcaflow_plugin_coremark_pro/coremark_pro_plugin.py
+++ b/arcaflow_plugin_coremark_pro/coremark_pro_plugin.py
@@ -162,6 +162,7 @@ def certify_all(
                 ca_results[log_name]["Iterations"] = int(log_list[7])
 
     return "success", SuccessOutput(
+        coremark_pro_command=' '.join(ca_cmd),
         coremark_pro_params=params,
         coremark_pro_results=certifyAllResultSchema.unserialize(ca_results),
     )

--- a/arcaflow_plugin_coremark_pro/coremark_pro_plugin.py
+++ b/arcaflow_plugin_coremark_pro/coremark_pro_plugin.py
@@ -16,10 +16,10 @@ from coremark_pro_schema import (
 )
 
 
-def run_oneshot_cmd(command_list, workdir) -> str:
+def run_oneshot_cmd(command, workdir) -> str:
     try:
         cmd_out = subprocess.check_output(
-            command_list,
+            command,
             stderr=subprocess.STDOUT,
             text=True,
             cwd=workdir,
@@ -120,7 +120,7 @@ def certify_all(
         xcmd.append(f"-w{params.workers}")
     ca_cmd.append(f"XCMD={' '.join(xcmd)!r}")
 
-    ca_cmd_string = ' '.join(ca_cmd)
+    ca_cmd_string = " ".join(ca_cmd)
 
     # Run certify-all
     ca_return = run_oneshot_cmd(ca_cmd_string, "/root/coremark-pro")
@@ -142,9 +142,9 @@ def certify_all(
     }
 
     # Construct the output object
-    search = re.compile(r'^(\s+|Starting|Workload|-|Mark)', re.IGNORECASE)
+    exclusion_search = re.compile(r"^(\s+|Starting|Workload|-|Mark)", re.IGNORECASE)
     for line in ca_return[1].splitlines():
-        if search.match(line):
+        if exclusion_search.match(line):
             continue
         line_list = line.split()
         try:
@@ -169,7 +169,7 @@ def certify_all(
                 ca_results[log_name]["Iterations"] = int(log_list[7])
 
     return "success", SuccessOutput(
-        coremark_pro_command=' '.join(ca_cmd),
+        coremark_pro_command=ca_cmd_string,
         coremark_pro_params=params,
         coremark_pro_results=certifyAllResultSchema.unserialize(ca_results),
     )

--- a/arcaflow_plugin_coremark_pro/coremark_pro_plugin.py
+++ b/arcaflow_plugin_coremark_pro/coremark_pro_plugin.py
@@ -117,6 +117,8 @@ def certify_all(
         xcmd.append(f"-c{params.contexts}")
     if params.workers:
         xcmd.append(f"-w{params.workers}")
+    # The coremark `make` command passes parameters to the individual benchmarks via
+    # the sub-parameters provided to the XCMD variable
     ca_cmd.append(f"XCMD={' '.join(xcmd)}")
 
     # Run certify-all

--- a/arcaflow_plugin_coremark_pro/coremark_pro_plugin.py
+++ b/arcaflow_plugin_coremark_pro/coremark_pro_plugin.py
@@ -19,7 +19,11 @@ from coremark_pro_schema import (
 def run_oneshot_cmd(command_list, workdir) -> str:
     try:
         cmd_out = subprocess.check_output(
-            command_list, stderr=subprocess.STDOUT, text=True, cwd=workdir
+            command_list,
+            stderr=subprocess.STDOUT,
+            text=True,
+            cwd=workdir,
+            shell=True,
         )
     except subprocess.CalledProcessError as error:
         return "error", ErrorOutput(
@@ -116,8 +120,10 @@ def certify_all(
         xcmd.append(f"-w{params.workers}")
     ca_cmd.append(f"XCMD={' '.join(xcmd)!r}")
 
+    ca_cmd_string = ' '.join(ca_cmd)
+
     # Run certify-all
-    ca_return = run_oneshot_cmd(ca_cmd, "/root/coremark-pro")
+    ca_return = run_oneshot_cmd(ca_cmd_string, "/root/coremark-pro")
 
     if ca_return[0] == "error":
         return ca_return

--- a/arcaflow_plugin_coremark_pro/coremark_pro_plugin.py
+++ b/arcaflow_plugin_coremark_pro/coremark_pro_plugin.py
@@ -136,8 +136,9 @@ def certify_all(
     }
 
     # Construct the output object
+    search = re.compile(r'^(\s+|Starting|Workload|-|Mark)', re.IGNORECASE)
     for line in ca_return[1].splitlines():
-        if re.match(r'^(\s+|Starting|W(?i)[orkload]|-|M(?i)[ark])', line):
+        if search.match(line):
             continue
         line_list = line.split()
         try:

--- a/arcaflow_plugin_coremark_pro/coremark_pro_plugin.py
+++ b/arcaflow_plugin_coremark_pro/coremark_pro_plugin.py
@@ -16,10 +16,10 @@ from coremark_pro_schema import (
 )
 
 
-def run_oneshot_cmd(command, workdir) -> str:
+def run_oneshot_cmd(command_list, workdir) -> str:
     try:
         cmd_out = subprocess.check_output(
-            command,
+            command_list,
             stderr=subprocess.STDOUT,
             text=True,
             cwd=workdir,

--- a/arcaflow_plugin_coremark_pro/coremark_pro_plugin.py
+++ b/arcaflow_plugin_coremark_pro/coremark_pro_plugin.py
@@ -23,7 +23,6 @@ def run_oneshot_cmd(command, workdir) -> str:
             stderr=subprocess.STDOUT,
             text=True,
             cwd=workdir,
-            shell=True,
         )
     except subprocess.CalledProcessError as error:
         return "error", ErrorOutput(
@@ -118,12 +117,10 @@ def certify_all(
         xcmd.append(f"-c{params.contexts}")
     if params.workers:
         xcmd.append(f"-w{params.workers}")
-    ca_cmd.append(f"XCMD={' '.join(xcmd)!r}")
-
-    ca_cmd_string = " ".join(ca_cmd)
+    ca_cmd.append(f"XCMD={' '.join(xcmd)}")
 
     # Run certify-all
-    ca_return = run_oneshot_cmd(ca_cmd_string, "/root/coremark-pro")
+    ca_return = run_oneshot_cmd(ca_cmd, "/root/coremark-pro")
 
     if ca_return[0] == "error":
         return ca_return
@@ -169,7 +166,7 @@ def certify_all(
                 ca_results[log_name]["Iterations"] = int(log_list[7])
 
     return "success", SuccessOutput(
-        coremark_pro_command=ca_cmd_string,
+        coremark_pro_command=" ".join(ca_cmd),
         coremark_pro_params=params,
         coremark_pro_results=certifyAllResultSchema.unserialize(ca_results),
     )

--- a/arcaflow_plugin_coremark_pro/coremark_pro_schema.py
+++ b/arcaflow_plugin_coremark_pro/coremark_pro_schema.py
@@ -197,6 +197,11 @@ certifyAllResultSchema = plugin.build_object_schema(CertifyAllResult)
 
 @dataclass
 class SuccessOutput:
+    coremark_pro_command: typing.Annotated[
+        str,
+        schema.name("CoreMark®-PRO command line"),
+        schema.description("The complete command line passed to CoreMark®-PRO"),
+    ]
     coremark_pro_params: typing.Annotated[
         CertifyAllParams,
         schema.name("Test Params"),

--- a/tests/test_arcaflow_plugin_coremark_pro.py
+++ b/tests/test_arcaflow_plugin_coremark_pro.py
@@ -14,8 +14,8 @@ from arcaflow_plugin_sdk import plugin
 
 
 tune_iterations_input = TuneIterationsInput(
-    contexts=1,
-    workers=1,
+    contexts=2,
+    workers=2,
     target_run_time=2,
 )
 
@@ -33,8 +33,8 @@ iterations = Iterations(
 
 certify_all_input = CertifyAllInput(
     verify=True,
-    contexts=1,
-    workers=1,
+    contexts=2,
+    workers=2,
     iterations=iterations,
 )
 
@@ -81,8 +81,8 @@ class CoreMarkProTest(unittest.TestCase):
         )
 
         self.assertEqual(ti_output_id, "success")
-        self.assertEqual(ti_output_data.contexts, 1)
-        self.assertEqual(ti_output_data.workers, 1)
+        self.assertEqual(ti_output_data.contexts, 2)
+        self.assertEqual(ti_output_data.workers, 2)
         self.assertIsInstance(ti_output_data.iterations.core, int)
 
         ca_output_id, ca_output_data = coremark_pro_plugin.certify_all(
@@ -90,8 +90,8 @@ class CoreMarkProTest(unittest.TestCase):
         )
 
         self.assertEqual(ca_output_id, "success")
-        self.assertEqual(ca_output_data.coremark_pro_params.contexts, 1)
-        self.assertEqual(ca_output_data.coremark_pro_params.workers, 1)
+        self.assertEqual(ca_output_data.coremark_pro_params.contexts, 2)
+        self.assertEqual(ca_output_data.coremark_pro_params.workers, 2)
         self.assertEqual(
             ca_output_data.coremark_pro_params.iterations.core,
             ca_output_data.coremark_pro_results.core.iterations,
@@ -99,6 +99,18 @@ class CoreMarkProTest(unittest.TestCase):
         self.assertIsInstance(
             ca_output_data.coremark_pro_results.core.multi_core,
             float,
+        )
+        self.assertGreater(
+            ca_output_data.coremark_pro_results.core.multi_core,
+            ca_output_data.coremark_pro_results.core.single_core,
+        )
+        self.assertAlmostEqual(
+            ca_output_data.coremark_pro_results.core.multi_core,
+            (
+                ca_output_data.coremark_pro_results.core.single_core *
+                ca_output_data.coremark_pro_results.core.scaling
+            ),
+            1,
         )
 
 

--- a/tests/test_arcaflow_plugin_coremark_pro.py
+++ b/tests/test_arcaflow_plugin_coremark_pro.py
@@ -107,8 +107,8 @@ class CoreMarkProTest(unittest.TestCase):
         self.assertAlmostEqual(
             ca_output_data.coremark_pro_results.core.multi_core,
             (
-                ca_output_data.coremark_pro_results.core.single_core *
-                ca_output_data.coremark_pro_results.core.scaling
+                ca_output_data.coremark_pro_results.core.single_core
+                * ca_output_data.coremark_pro_results.core.scaling
             ),
             1,
         )


### PR DESCRIPTION
## Changes introduced with this PR

~~When coremark runs `make` in a python `subprocess`, it seems to be not allowed to spawn the multiple testing threads needed when multiple contexts are used, resulting in invalid results. This fix introduces a change in the way the `subprocess` is called, allowing for the required multithreaded behavior.~~

The `make` command called by `subprocess` to run the coremark-pro benchmarks uses an `XCMD=` set of sub-parameters that are passed on to the individual benchmarks. It turns out that quoting the string passed to `XCMD=` causes a parsing problem when those sub-parameters are passed to the benchmarks. This change removes the quote marks from the string.

Also adds the command line to the output, and improves a regex use to remove a deprecation warning message.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).