### PR TITLE
Remove generated requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-arcaflow-plugin-sdk==0.14.2 ; python_version >= "3.9" and python_version < "4.0"
-cbor2==5.6.4 ; python_version >= "3.9" and python_version < "4.0"
-pyyaml==6.0.2 ; python_version >= "3.9" and python_version < "4.0"


### PR DESCRIPTION
## Changes introduced with this PR

The `requirements.txt` file is generated and consumed within the `Dockerfile`; thus, there is no need to maintain it in the repository, and doing so prompts the Renovate bot to try to maintain it (e.g., see #12) which is a waste.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).